### PR TITLE
Fix GetPlayArea and InitBoundaries for SDK_WindowsMRBoundaries

### DIFF
--- a/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRBoundaries.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRBoundaries.cs
@@ -49,11 +49,11 @@ namespace VRTK
                 {
                     cachedPlayArea = headsetCamera.transform;
                 }
-            }
 
-            if (cachedPlayArea != null && cachedPlayArea.parent != null)
-            {
-                cachedPlayArea = cachedPlayArea.parent;
+                if (cachedPlayArea != null && cachedPlayArea.parent != null)
+                {
+                    cachedPlayArea = cachedPlayArea.parent;
+                }
             }
 
             return cachedPlayArea;
@@ -121,6 +121,11 @@ namespace VRTK
             if (headsetCamera != null)
             {
                 cachedPlayArea = headsetCamera.transform;
+
+                if (cachedPlayArea != null && cachedPlayArea.parent != null)
+                {
+                    cachedPlayArea = cachedPlayArea.parent;
+                }
             }
         }
 

--- a/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRBoundaries.cs
+++ b/Assets/VRTK/Source/SDK/WindowsMR/SDK_WindowsMRBoundaries.cs
@@ -121,11 +121,11 @@ namespace VRTK
             if (headsetCamera != null)
             {
                 cachedPlayArea = headsetCamera.transform;
+            }
 
-                if (cachedPlayArea != null && cachedPlayArea.parent != null)
-                {
-                    cachedPlayArea = cachedPlayArea.parent;
-                }
+            if (cachedPlayArea != null && cachedPlayArea.parent != null)
+            {
+                cachedPlayArea = cachedPlayArea.parent;
             }
         }
 


### PR DESCRIPTION
InitBoundaries incorrectly set the headset as the play area and GetPlayArea incorrectly return the parent of the cachedPlayArea as the play area every time the method is called